### PR TITLE
bug: fixes lag spike on trench dig event for vehicles

### DIFF
--- a/addons/vehicle_trenches/functions/fnc_lowerPlow.sqf
+++ b/addons/vehicle_trenches/functions/fnc_lowerPlow.sqf
@@ -52,5 +52,5 @@ hintSilent "Lowering plow...";
 	_vehicle setVariable [QGVAR(plowMode), _plowMode, true];
 	hintSilent "Plow lowered.";
 	// Add frame event handler for the lowered plow
-	[QGVAR(addBuildHandler), [_vehicle]] call CBA_fnc_serverEvent;
+	[QGVAR(addBuildHandler), [_vehicle]] call CBA_fnc_localEvent;
 }, [_vehicle, _type, _animation, _plowLowered, _plowMode]] call CBA_fnc_waitUntilAndExecute;

--- a/addons/vehicle_trenches/functions/fnc_lowerPlow.sqf
+++ b/addons/vehicle_trenches/functions/fnc_lowerPlow.sqf
@@ -52,5 +52,5 @@ hintSilent "Lowering plow...";
 	_vehicle setVariable [QGVAR(plowMode), _plowMode, true];
 	hintSilent "Plow lowered.";
 	// Add frame event handler for the lowered plow
-	[QGVAR(addBuildHandler), [_vehicle]] call CBA_fnc_globalEvent;
+	[QGVAR(addBuildHandler), [_vehicle]] call CBA_fnc_serverEvent;
 }, [_vehicle, _type, _animation, _plowLowered, _plowMode]] call CBA_fnc_waitUntilAndExecute;


### PR DESCRIPTION
Fixes #91 

This particular performance issue arose from a registered CBA globalevent, which should have been executed on a single client only. All of the logic for digging the trench was executed on _all clients simultaneously_, causing few problems in testing where a small number of clients were connected, but _massive_ performance drains in an operation where 12 people are playing at once. 