### PR TITLE
Fix: pylon/turret config

### DIFF
--- a/addons/air/heli_raptor/CfgVehicles.inc
+++ b/addons/air/heli_raptor/CfgVehicles.inc
@@ -27,6 +27,14 @@ class CfgVehicles
       , "SWS_Camo"    , 0
     };
 
+    class PilotCamera : PilotCamera
+    {
+      minTurn = -140;
+      maxTurn = 140;
+      maxMouseXRotSpeed = 1;
+      maxMouseYRotSpeed = 1;
+    };
+
     class TextureSources : TextureSources
     {
       class Black;
@@ -71,7 +79,6 @@ class CfgVehicles
               , "UNI_SCALPEL"
               , "DAGR"
             };
-            turret[] = { 0 };
             uiPosition[] = { 0.06, 0.4 };
           };
           class PylonLeft2 : PylonLeft1

--- a/addons/air/heli_raptor/config.cpp
+++ b/addons/air/heli_raptor/config.cpp
@@ -1,6 +1,7 @@
 #include "script_component.hpp"
 
 class Components;
+class PilotCamera;
 class TextureSources;
 
 #include "CfgVehicles.inc"


### PR DESCRIPTION
- Pylons now correctly default to pilot's controls
- pilotCamera rotation max buff (240 degrees -> 280 degrees) so you can see what you're orbiting better
- pilotCamera rotation speed buff (0.5 -> 1)