### PR TITLE
feat(weapons): Clarify AR magazine names

### DIFF
--- a/addons/weapons/ar0m37s/CfgMagazines.inc
+++ b/addons/weapons/ar0m37s/CfgMagazines.inc
@@ -12,7 +12,7 @@ class CfgMagazines
   {
     ITEM_META(2);
     CLEARANCE(RESTRICTED/DECWHI);
-    displayName = QNAME(60Rnd 6.5mm Promet Mag);
+    displayName = QNAME(60Rnd 6.5mm 0M37S Mag);
     descriptionShort = "AR-0M37S 6.5mm Ammunition";
     lastRoundsTracer = 5;
     count = 60;
@@ -21,13 +21,13 @@ class CfgMagazines
 
   class SWS_Magazine_60Rnd_65x39_Caseless_MSBS_Tracers : SWS_Magazine_60Rnd_65x39_Caseless_MSBS
   {
-    displayName = QNAME(60Rnd 6.5mm Promet Mag (Red Tracer));
+    displayName = QNAME(60Rnd 6.5mm 0M37S Mag (Red Tracer));
     tracersEvery = 1;
   };
 
 #define C_TRACERS(varColor) \
   class SWS_Magazine_60Rnd_65x39_Caseless_MSBS_Tracers_##varColor : SWS_Magazine_60Rnd_65x39_Caseless_MSBS_Tracers \
-  { displayName = QNAME(60Rnd 6.5mm Promet Mag (varColor Tracer)); ammo = QUOTE(B_65x39_Caseless_##varColor); }
+  { displayName = QNAME(60Rnd 6.5mm 0M37S Mag (varColor Tracer)); ammo = QUOTE(B_65x39_Caseless_##varColor); }
 
   C_TRACERS(Blue);
   C_TRACERS(Yellow);

--- a/addons/weapons/armxs/CfgMagazines.inc
+++ b/addons/weapons/armxs/CfgMagazines.inc
@@ -12,7 +12,7 @@ class CfgMagazines
   {
     ITEM_META(2);
     CLEARANCE(RESTRICTED/DECWHI);
-    displayName = QNAME(60Rnd 6.5mm Mag);
+    displayName = QNAME(60Rnd 6.5mm MX Mag);
     descriptionShort = "ARMXS 6.5mm Ammunition";
     lastRoundsTracer = 5;
     count = 60;
@@ -21,13 +21,13 @@ class CfgMagazines
 
   class SWS_Magazine_60Rnd_65x39_Caseless_Tracers : SWS_Magazine_60Rnd_65x39_Caseless
   {
-    displayName = QNAME(60Rnd 6.5mm Mag (Red Tracer));
+    displayName = QNAME(60Rnd 6.5mm MX Mag (Red Tracer));
     tracersEvery = 1;
   };
 
 #define C_TRACERS(varColor) \
   class SWS_Magazine_60Rnd_65x39_Caseless_Tracers_##varColor : SWS_Magazine_60Rnd_65x39_Caseless_Tracers \
-  { displayName = QNAME(60Rnd 6.5mm Promet Mag (varColor Tracer)); ammo = QUOTE(B_65x39_Caseless_##varColor); }
+  { displayName = QNAME(60Rnd 6.5mm MX Mag (varColor Tracer)); ammo = QUOTE(B_65x39_Caseless_##varColor); }
 
   C_TRACERS(Blue);
   C_TRACERS(Yellow);


### PR DESCRIPTION
- Replace 'Promet' with '0M37S' for the MSBS magazines.
- Remove 'Promet' where it should not have been for the AR-MXS magazines.