### PR TITLE
feat(statics): Allow FG-75 to be destroyed

### DIFF
--- a/addons/statics/CfgEventHandlers.inc
+++ b/addons/statics/CfgEventHandlers.inc
@@ -17,17 +17,22 @@ class Extended_Killed_EventHandlers {
   // Patch the M41 + derivatives to replace the object with the base when it's destroyed
   class OPTRE_Static_M41 {
     class SUBADDON {
-      clientKilled = QUOTE(_this call FUNC(optreReplaceStatic));
+      clientKilled = QUOTE([ARR_2(_this select 0,""OPTRE_Static_Base_Turret"")] call FUNC(optreReplaceStatic));
     };
   };
   class OPTRE_Static_ATGM {
     class SUBADDON {
-      clientKilled = QUOTE(_this call FUNC(optreReplaceStatic));
+      clientKilled = QUOTE([ARR_2(_this select 0,""OPTRE_Static_Base_Turret"")] call FUNC(optreReplaceStatic));
     };
   };
   class OPTRE_Static_AA {
     class SUBADDON {
-      clientKilled = QUOTE(_this call FUNC(optreReplaceStatic));
+      clientKilled = QUOTE([ARR_2(_this select 0,""OPTRE_Static_Base_Turret"")] call FUNC(optreReplaceStatic));
+    };
+  };
+  class OPTRE_Static_FG75 {
+    class SUBADDON {
+      clientKilled = QUOTE([_this select 0] call FUNC(optreReplaceStatic));
     };
   };
 };

--- a/addons/statics/CfgVehicles.inc
+++ b/addons/statics/CfgVehicles.inc
@@ -24,4 +24,9 @@ class CfgVehicles {
     // Based on the Stomper's effects
     class DestructionEffects : GVAR(OPTRE_DestructionEffectsTemplate) {};
   };
+  // FG75 AT Gun
+  class OPTRE_Static_FG75 : StaticMGWeapon {
+    armor = 400;
+    class DestructionEffects : GVAR(OPTRE_DestructionEffectsTemplate) {};
+  };
 };

--- a/addons/statics/functions/fnc_optreReplaceStatic.sqf
+++ b/addons/statics/functions/fnc_optreReplaceStatic.sqf
@@ -2,21 +2,25 @@
 
 /*
  * Author: Maid
- * Replace the OPTRE static weapons with just their base after a short delay.
+ * Replace the OPTRE static weapons with just their base or delete after a short delay.
  *
  * Arguments:
  * 0: vehicle <OBJECT> - The optre defense to replace (M41, for example)
+ * 1: replaceWith <STRING> - OPTIONAL The simple object to put when it is replaced; if excluded, the vehicle will just be deleted.
  *
  * Return Value:
  * None
  *
  * Example:
- * [_myCutestM41Emplacement] call sws_statics_fnc_optreReplaceStatic;
+ * [_myCutestM41Emplacement, "OPTRE_Static_Base_Turret"] call sws_statics_fnc_optreReplaceStatic;
  *
  * Public: No
  */
 
-params ["_vic"];
+params [
+  ["_vic", objNull, [objNull]],
+  ["_replaceWith", nil, ["", nil]]
+];
 if !(local _vic) exitWith {
   TRACE_1("optreReplaceStatic should be run local to the vehicle only",_vic);
 };
@@ -24,9 +28,10 @@ private _destructionDuration = floor (random 10) + 3;
 TRACE_2("Replacing object soon",_vic,_destructionDuration);
 
 [{
-  params ["_vic"];
+  params ["_vic", "_replaceWith"];
   private _pos = getPosWorld _vic;
   deleteVehicle _vic;
-  createSimpleObject ["OPTRE_Static_Base_Turret", _pos];
-}, [_vic], _destructionDuration] call CBA_fnc_waitAndExecute;
+  if (isNil {_replaceWith}) exitWith {};
+  createSimpleObject [_replaceWith, _pos];
+}, [_vic, _replaceWith], _destructionDuration] call CBA_fnc_waitAndExecute;
 


### PR DESCRIPTION
<!-- Make sure you change the title of the PR above. Typically, you'll want it to match the following format: -->
<!-- feat/fix(addon?): Brief description of ten words or less; for example: feat(gear): Added a new armor variant  -->
<!-- If it changes multiple addons, you can either pick the major one it effects or omit the 'addon' portion, e.g. feat: Reworked a bunch of textures -->
<!-- The title above is what will appear in the changelog when a new release is made. -->

## Describe your changes

Partially resolves #125; allows the model to burn and be deleted. Temporary measure while we work on something better.

It has more armor than the other OPTRE statics, closer to a tank than an APC.

## Screenshots (if appropriate)

<!-- Including a screenshot or two can help with reviewing PRs as well as looking back at them later. -->
