### PR TITLE
feat(arsenal): Save last exited items as loadout

### DIFF
--- a/addons/arsenal/XEH_PREP.inc.sqf
+++ b/addons/arsenal/XEH_PREP.inc.sqf
@@ -1,3 +1,4 @@
 PREP(addFullArsenal);
 PREP(attributeAddDefaults);
 PREP(moduleAddFullArsenal);
+PREP(saveLoadoutWithName);

--- a/addons/arsenal/XEH_postInit.sqf
+++ b/addons/arsenal/XEH_postInit.sqf
@@ -1,1 +1,10 @@
 #include "script_component.hpp"
+
+["ace_arsenal_loadoutsDisplayClosed", {
+  if !(GVAR(saveLastLoadout)) exitWith {};
+  private _target = currentNamespace getVariable ["ace_arsenal_center", player];
+  if !(local _target || {!(_target isEqualTo player)}) exitWith {
+    TRACE_1("Non-player target",_target);
+  };
+  [GVAR(lastLoadoutName), player call CBA_fnc_getLoadout] call FUNC(saveLoadoutWithName);
+}] call CBA_fnc_addEventHandler;

--- a/addons/arsenal/XEH_preInit.sqf
+++ b/addons/arsenal/XEH_preInit.sqf
@@ -4,3 +4,4 @@ ADDON = false;
 ADDON = true;
 
 
+#include "initSettings.inc.sqf"

--- a/addons/arsenal/functions/fnc_saveLoadoutWithName.sqf
+++ b/addons/arsenal/functions/fnc_saveLoadoutWithName.sqf
@@ -1,0 +1,43 @@
+#include "script_component.inc.sqf"
+
+/*
+ * Author: Maid
+ * Save a loadout programmatically. This can overwrite existing loadouts.
+ *
+ * Arguments:
+ * 0: Loadout name <STRING>
+ * 1: Loadout or extended CBA loadout. This will be mutated, be careful! <ARRAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["My Cool Loadout", player call CBA_fnc_getLoadout] call sws_arsenal_fnc_saveLoadoutWithName;
+ *
+ * Public: No
+ */
+
+TRACE_1(QGVAR(fnc_saveLoadoutWithName),_this);
+
+params [
+  ["_loadoutName", "", [""]],
+  "_mut_loadout"
+];
+
+private _loadout = [_mut_loadout] call ace_arsenal_fnc_replaceUniqueItemsLoadout;
+private _loadoutMetadata = [[], _mut_loadout select 1] select (count _mut_loadout == 2);
+private _extendedLoadout = [_loadout, _loadoutMetadata];
+
+private _loadouts = profileNamespace getVariable ["ace_arsenal_saved_loadouts", []];
+private _mut_loadoutIndex = _loadouts findIf {(_x select 0) == _loadoutName};
+
+if (_mut_loadoutIndex == -1) then {
+  _mut_loadoutIndex = _loadouts pushBack [_loadoutName, _extendedLoadout];
+} else {
+  _loadouts set [_mut_loadoutIndex, [_loadoutName, _extendedLoadout]];
+};
+
+profileNamespace setVariable ["ace_arsenal_saved_loadouts", _loadouts];
+
+["ace_arsenal_onLoadoutSave", [_mut_loadoutIndex, _loadout]] call CBA_fnc_localEvent;
+["ace_arsenal_onLoadoutSaveExtended", [_mut_loadoutIndex, _extendedLoadout]] call CBA_fnc_localEvent;

--- a/addons/arsenal/initSettings.inc.sqf
+++ b/addons/arsenal/initSettings.inc.sqf
@@ -1,0 +1,25 @@
+#define CATEGORY QNAME(General)
+
+[
+  QGVAR(saveLastLoadout),
+  "CHECKBOX",
+  ["Save Last Loadout", "When exiting the arsenal, save the items you have as a loadout. Warning: Disabling this will prevent you from easy resupplies."],
+  [CATEGORY, "ACE Arsenal"],
+  true,
+  0,
+  {
+    params ["_newValue"];
+    if (_newValue) exitWith {};
+    systemChat "Warning: You have disabled saving your last loadout from the ACE Arsenal. This will make Zeus resupplying your loadout more difficult.";
+  }
+] call CBA_fnc_addSetting;
+
+[
+  QGVAR(lastLoadoutName),
+  "EDITBOX",
+  ["Last Loadout Name", "When saving a loadout with Save Last Loadout, it will be saved using this name."],
+  [CATEGORY, "ACE Arsenal"],
+  "[SWS] Last Arsenal Loadout",
+  0
+] call CBA_fnc_addSetting;
+


### PR DESCRIPTION
<!-- Make sure you change the title of the PR above. Typically, you'll want it to match the following format: -->
<!-- feat/fix(addon?): Brief description of ten words or less; for example: feat(gear): Added a new armor variant  -->
<!-- If it changes multiple addons, you can either pick the major one it effects or omit the 'addon' portion, e.g. feat: Reworked a bunch of textures -->
<!-- The title above is what will appear in the changelog when a new release is made. -->

## Describe your changes

<!-- Below this line, include a brief description of what your PR accomplishes. One to two sentences is fine; the goal is so that someone can look back at the PR to see a description of changes that isn't briefly describe in the title. -->

Whenever you exit the arsenal, this will now save the items you have equipped as a loadout. I'm planning to use this data for a resupply module in #27.

## Screenshots (if appropriate)

<!-- Including a screenshot or two can help with reviewing PRs as well as looking back at them later. -->

![image](https://github.com/WitchFreya/SWSAddons/assets/9843550/869d72aa-cca2-4040-ad57-636d8e3c1244)

Disregard the Resupply section there for right now, I'm working on that.

![image](https://github.com/WitchFreya/SWSAddons/assets/9843550/4e5fca52-0c7e-4c22-93bd-4c1befb3a08c)

