### PR TITLE
fix: Make rail attachment and Howdy configs consistent and work with loadouts

### DIFF
--- a/addons/patches/optre_ace_compat/CfgWeapons.inc
+++ b/addons/patches/optre_ace_compat/CfgWeapons.inc
@@ -1,14 +1,67 @@
 class CfgWeapons {
   class ARifle_Mk20_F;
   class OPTRE_Rifle_Base;
+  class ACC_Pointer_IR;
+  class ItemCore;
+  class ACC_Flashlight;
 
+  #pragma region Remove class flashlights to avoid conflict with CBA flashlights
   class OPTRE_MA37K : ARifle_Mk20_F {
-    // Removed to avoid conflict with CBA flashlights
     delete FlashLight;
   };
 
   class OPTRE_MA5B : OPTRE_Rifle_Base {
-    // Removed to avoid conflict with CBA flashlights
     delete FlashLight;
   };
+  #pragma endregion
+
+  #pragma region Their attachments are a mess.
+  class OPTRE_M7_Laser : ACC_Pointer_IR {
+    ace_arsenal_uniqueBase = "OPTRE_M7_Laser";
+  };
+  class OPTRE_M7_Flashlight : ItemCore {
+    scopeArsenal = 1;
+    ace_arsenal_uniqueBase = "OPTRE_M7_Laser";
+  };
+
+  // The BMR MEQ Variant
+  class OPTRE_BMR_Laser : ACC_Pointer_IR {
+    ace_arsenal_uniqueBase = "OPTRE_BMR_Laser";
+  };
+
+  // The BMR standard variant, modified so the Lasers appear instead of MEQ and Flashlight.
+  class OPTRE_BMR_Flashlight : ACC_Flashlight {
+    scope = 2;
+    scopeArsenal = 1;
+    ace_arsenal_uniqueBase = "OPTRE_BMR_Flashlight_Laser";
+  };
+  class OPTRE_BMR_Flashlight_Laser : OPTRE_BMR_Flashlight {
+    scopeArsenal = 2;
+  };
+
+  class OPTRE_M6G_Flashlight : ItemCore {
+    ace_arsenal_uniqueBase = "OPTRE_M6G_Flashlight";
+  };
+
+  class OPTRE_M6C_Laser : ACC_Pointer_IR {
+    ace_arsenal_uniqueBase = "OPTRE_M6C_Laser";
+  };
+
+  class OPTRE_M6C_Flashlight : OPTRE_M6G_Flashlight {
+    ace_arsenal_uniqueBase = "OPTRE_M6C_Flashlight";
+  };
+
+  class OPTRE_M12_Flashlight : OPTRE_M7_Flashlight {
+    ace_arsenal_uniqueBase = "OPTRE_M12_Laser";
+  };
+
+  // DMR light no variants so clearing out the invalid CBA properties and setting the appropriate ones.
+  class OPTRE_DMR_Light : OPTRE_BMR_Flashlight {
+    MRT_switchItemHintText = "";
+    MRT_SwitchItemNextClass = "";
+    MRT_SwitchItemPrevClass = "";
+    scopeArsenal = 2;
+    picture = "\OPTRE_Weapons\br\icons\flashlight.paa";
+  };
+  #pragma endregion
 };

--- a/addons/weapons/howdy/CfgWeapons.inc
+++ b/addons/weapons/howdy/CfgWeapons.inc
@@ -4,53 +4,60 @@
 #define NAME_M24RLD NAME(M24RL-Sx 'Howdy')
 
 class CBA_DisposableLaunchers {
-  SWS_Weapon_M24RL_D[] = { "SWS_Weapon_M24RL_D_Loaded", "SWS_Weapon_M24RL_D_Used" };
+  SWS_Weapon_M24RL_D_Loaded[] = { "SWS_Weapon_M24RL_D", "SWS_Weapon_M24RL_D_Used" };
 };
 
 class CfgWeapons {
   class Launch_MRAWS_Green_F;
 
   class SWS_Weapon_M24RL_D : Launch_MRAWS_Green_F {
-    ITEM_META(1);
+    ITEM_META(2);
     CLEARANCE(RESTRICTED/DECWHITE);
-    displayName = QUOTE(NAME_M24RLD);
-    baseWeapon = "SWS_Weapon_M24RL_D_Loaded";
+    displayName = QUOTE(NAME_M24RLD (Disposable));
+    baseWeapon = "SWS_Weapon_M24RL_D";
     picture = QPATHTOF(data\icons\m24rl_d_ca.paa);
     pictureWire = QPATHTOF(data\icons\m24rl_d_wire_ca.paa);
     model = QPATHTOF(data\m24rl_d\m24rl_d.p3d);
-    handAnim[] = {"OFP2_ManSkeleton", "\A3\Weapons_F\Launchers\RPG32\data\Anim\RPG32.rtm"};
-    magazines[] = {"SWS_Magazine_M24RL_D"};
-    magazineReloadTime = 0.1;
-    reloadMagazineSound[] = {"",1,1};
+
     description = "A single-use dumbfire rocket launcher that will make short work of most targets.";
     descriptionShort = "Disposable dumbfire. 'Howdy' is the last thing they'll hear.";
+
+    handAnim[] = {"OFP2_ManSkeleton", "\A3\Weapons_F\Launchers\RPG32\data\Anim\RPG32.rtm"};
+    magazines[] = {"CBA_FakeLauncherMagazine"};
+    magazineWell[] = {};
+    magazineReloadTime = 0.1;
+    reloadMagazineSound[] = {"",1,1};
 
     // backblast
     ACE_overpressure_angle = 55;
     ACE_overpressure_range = 10;
 
-    class EventHandlers {
-      fired = "_this call CBA_fnc_firedDisposable";
-    };
-
     class WeaponSlotsInfo: WeaponSlotsInfo {
-      mass = MASS_WEAPON;
-    };
-  };
-
-  class SWS_Weapon_M24RL_D_Loaded : SWS_Weapon_M24RL_D {
-    SCOPE(2);
-    displayName = QUOTE(NAME_M24RLD (Disposable));
-    magazines[] = {"CBA_FakeLauncherMagazine"};
-    class WeaponSlotsInfo : WeaponSlotsInfo {
       mass = MASS_WEAPON + MASS_MAG;
     };
   };
 
+  class SWS_Weapon_M24RL_D_Loaded : SWS_Weapon_M24RL_D {
+    SCOPE(1);
+    displayName = QUOTE(NAME_M24RLD);
+    magazines[] = {"SWS_Magazine_M24RL_D"};
+
+    class EventHandlers {
+      fired = "_this call CBA_fnc_firedDisposable";
+    };
+
+    class WeaponSlotsInfo : WeaponSlotsInfo {
+      mass = MASS_WEAPON;
+    };
+  };
+
   class SWS_Weapon_M24RL_D_Used : SWS_Weapon_M24RL_D {
-    displayName = QUOTE(NAME_M24RLD (Used));
+    SCOPE(1);
+    displayName = QUOTE(Used NAME_M24RLD);
     baseWeapon = "SWS_Weapon_M24RL_D_Used";
-    magazines[] = {"CBA_FakeLauncherMagazine"};
+    class WeaponSlotsInfo: WeaponSlotsInfo {
+      mass = MASS_WEAPON;
+    };
   };
 };
 


### PR DESCRIPTION
<!-- Make sure you change the title of the PR above. Typically, you'll want it to match the following format: -->
<!-- feat/fix(addon?): Brief description of ten words or less; for example: feat(gear): Added a new armor variant  -->
<!-- If it changes multiple addons, you can either pick the major one it effects or omit the 'addon' portion, e.g. feat: Reworked a bunch of textures -->
<!-- The title above is what will appear in the changelog when a new release is made. -->

## Describe your changes

<!-- Below this line, include a brief description of what your PR accomplishes. One to two sentences is fine; the goal is so that someone can look back at the PR to see a description of changes that isn't briefly describe in the title. -->

This fix uniformly patches the OPTRE lasers to properly consolidate in a loadout and avoid saving a loadout that'll get invalidated due to a missing attachment. It also corrects the config definition for the Howdy launcher.

While this will break some existing loadouts, it's for the best in the long-run. To correct the loadouts you'll have that are now greyed out, do the following:
1. Under Addon Options > ACE Arsenal > Loadouts, enable `Log missing/unavailable items in the RPT` if it is not already enabled.
2. Open the Loadouts window.
3. Open your RPT file. This can be found in your local app data; for Windows, hit Windows+R and enter `%localappdata%\Arma 3`. Sort this by 'Date Modified', and find the file ending in `.rpt` that was created most recently. It can be loaded in any text editor, Notepad is fine.
4. Search for "ACE_Arsenal - Loadout:". You'll find entries under it that look like this:
  ```
  ACE_Arsenal - Loadout:
  Name: TL Base
  Missing items: []
  Unavailable items: ["SWS_Magazine_M24RL_D"]
  Missing extended loadout: []
  ```
5. For loadouts that list just `Unavailable items: ["SWS_Magazine_M24RL_D"]`, you can simply load and save them again and they'll work fine. For loadouts that list other unavailable items, you'll want to load those and check the weapon rail attachments on your weapons before saving them again:
![image](https://github.com/WitchFreya/SWSAddons/assets/9843550/a1881197-5e2a-460e-963e-064dab2cec8d)


## Screenshots (if appropriate)

<!-- Including a screenshot or two can help with reviewing PRs as well as looking back at them later. -->
