### PR TITLE
fix(resupply): Retain radio settings when restocking

### DIFF
--- a/addons/arsenal/XEH_postInit.sqf
+++ b/addons/arsenal/XEH_postInit.sqf
@@ -1,10 +1,12 @@
 #include "script_component.hpp"
 
-["ace_arsenal_loadoutsDisplayClosed", {
-  if !(GVAR(saveLastLoadout)) exitWith {};
+["ace_arsenal_displayClosed", {
+  if !(GVAR(saveLastLoadout)) exitWith {
+    TRACE_1(QUOTE(GVAR(saveLastLoadout) not enabled),GVAR(saveLastLoadout));
+  };
   private _target = currentNamespace getVariable ["ace_arsenal_center", player];
   if !(local _target || {!(_target isEqualTo player)}) exitWith {
-    TRACE_1("Non-player target",_target);
+    TRACE_1("Invalid loadout save target",_target);
   };
   [GVAR(lastLoadoutName), player call CBA_fnc_getLoadout] call FUNC(saveLoadoutWithName);
 }] call CBA_fnc_addEventHandler;

--- a/addons/arsenal/initSettings.inc.sqf
+++ b/addons/arsenal/initSettings.inc.sqf
@@ -11,8 +11,7 @@
     params ["_newValue"];
     if (_newValue) exitWith {};
     systemChat "Warning: You have disabled saving your last loadout from the ACE Arsenal. This will make Zeus resupplying your loadout more difficult.";
-  },
-  true
+  }
 ] call CBA_fnc_addSetting;
 
 [

--- a/addons/tfar/XEH_PREP.inc.sqf
+++ b/addons/tfar/XEH_PREP.inc.sqf
@@ -1,6 +1,6 @@
-PREP(onLoadoutsDisplayOpened);
 PREP(onRadiosReceived);
 PREP(restoreLongRangeRadio);
 PREP(restoreShortRangeRadio);
 PREP(saveLongRangeRadio);
+PREP(saveRadios);
 PREP(saveShortRangeRadio);

--- a/addons/tfar/XEH_postInit.sqf
+++ b/addons/tfar/XEH_postInit.sqf
@@ -1,10 +1,17 @@
 #include "script_component.hpp"
 
 [QGVAR(OnRadiosReceived), "OnRadiosReceived", FUNC(onRadiosReceived)] call TFAR_fnc_addEventHandler;
-["ace_arsenal_loadoutsDisplayOpened", FUNC(onLoadoutsDisplayOpened)] call CBA_fnc_addEventHandler;
+["ace_arsenal_loadoutsDisplayOpened", {
+  private _target = currentNamespace getVariable ["ace_arsenal_center", player];
+  [_target] call FUNC(saveRadios);
+}] call CBA_fnc_addEventHandler;
+
+// Ensure that radio configuration doesn't get lost.
+[QEGVAR(resupply,restock), FUNC(saveRadios)] call CBA_fnc_addEventHandler;
 
 // Ensure locality.
 [QGVAR(restoreShortRangeRadio), FUNC(restoreShortRangeRadio)] call CBA_fnc_addEventHandler;
 [QGVAR(saveShortRangeRadio), FUNC(saveShortRangeRadio)] call CBA_fnc_addEventHandler;
 [QGVAR(restoreLongRangeRadio), FUNC(restoreLongRangeRadio)] call CBA_fnc_addEventHandler;
 [QGVAR(saveLongRangeRadio), FUNC(saveLongRangeRadio)] call CBA_fnc_addEventHandler;
+[QGVAR(saveRadios), FUNC(saveRadios)] call CBA_fnc_addEventHandler;

--- a/addons/tfar/functions/fnc_saveRadios.sqf
+++ b/addons/tfar/functions/fnc_saveRadios.sqf
@@ -2,23 +2,29 @@
 
 /*
  * Author: Maid
- * Handle the ACE arsenal loadoutsDisplayOpened event.
+ * Save the radio for a unit.
  *
  * Arguments:
- * 0: display <DISPLAY> - Loadout's display; unused here.
+ * 0: Unit to save the radio on <OBJECT>
  *
  * Return Value:
  * True on success
  *
  * Example:
- * [] call sws_tfar_fnc_onLoadoutsDisplayOpened;
+ * [player] call sws_tfar_fnc_saveRadios;
  *
  * Public: No
  */
 
-TRACE_1("ace_arsenal_loadoutsDisplayOpened",_this);
+TRACE_1(QGVAR(DOUBLES(fnc,saveRadios)),_this);
 
-private _target = currentNamespace getVariable ["ace_arsenal_center", player];
+if !(local _target) exitWith {
+  [QGVAR(saveRadios), [_target], _target] call CBA_fnc_targetEvent;
+};
+
+params [
+  ["_target", objNull, [objNull]]
+];
 
 switch (GVAR(restoreRadios)) do {
   case "sr_only": {


### PR DESCRIPTION
<!-- Make sure you change the title of the PR above. Typically, you'll want it to match the following format: -->
<!-- feat/fix(addon?): Brief description of ten words or less; for example: feat(gear): Added a new armor variant  -->
<!-- If it changes multiple addons, you can either pick the major one it effects or omit the 'addon' portion, e.g. feat: Reworked a bunch of textures -->
<!-- The title above is what will appear in the changelog when a new release is made. -->

## Describe your changes

<!-- Below this line, include a brief description of what your PR accomplishes. One to two sentences is fine; the goal is so that someone can look back at the PR to see a description of changes that isn't briefly describe in the title. -->

- Retains radio settings when restocking if save radio settings is enabled.
- Also fixes it so that the Last Loadout will be saved when exiting the arsenal instead of when exiting the Loadout window.

## Screenshots (if appropriate)

<!-- Including a screenshot or two can help with reviewing PRs as well as looking back at them later. -->
